### PR TITLE
Api breaks if domain protocol is not specified in the iFrame's src

### DIFF
--- a/javascript/froogaloop.js
+++ b/javascript/froogaloop.js
@@ -139,6 +139,10 @@ var Froogaloop = (function(){
                 method: method,
                 value: params
             });
+            
+        if(url.substr(0, 2) === '//') {
+            url = window.location.protocol + url;
+        }
 
         target.contentWindow.postMessage(data, url);
     }
@@ -242,6 +246,11 @@ var Froogaloop = (function(){
      * @return url (String): Root domain of submitted url
      */
     function getDomainFromUrl(url) {
+        
+        if(url.substr(0, 2) === '//') {
+            url = window.location.protocol + url;
+        }
+        
         var url_pieces = url.split('/'),
             domain_str = '';
 


### PR DESCRIPTION
If the src of the Vimeo iframe began with // instead of http:// or https:// the javascript API would not work. This patch fixes that bug.
