### PR TITLE
Fixed broken link to documentation.

### DIFF
--- a/javascript/readme.mdown
+++ b/javascript/readme.mdown
@@ -5,7 +5,7 @@ We suggest that you either host the JS file yourself, or link to our official ho
 
 [http://a.vimeocdn.com/js/froogaloop2.min.js](http://a.vimeocdn.com/js/froogaloop2.min.js)
 
-For more information on the JS API, see [our player documentation page](https://developer.vimeo.com/player/js-api).
+For more information on the JS API, see [our player documentation page](http://developer.vimeo.com/player/js-api).
 
 Until we meet again!
 - Brad (3/25/2011)


### PR DESCRIPTION
The link to the documentation was pointed to an https version of the page that no longer exists. The s has been removed and now the link works.
