### PR TITLE
catch undefined object or null error in getCallback method

### DIFF
--- a/javascript/froogaloop.js
+++ b/javascript/froogaloop.js
@@ -215,6 +215,9 @@ var Froogaloop = (function(){
      */
     function getCallback(eventName, target_id) {
         if (target_id) {
+            if (!eventCallbacks[target_id]) {
+                return null;
+            }
             return eventCallbacks[target_id][eventName];
         }
         else {


### PR DESCRIPTION
Fix the getCallback method if no event has been added for the current target_id 
then there will be no record in the eventCallbacks array for that target. 
This will throw a object is null or undefined error
