### PR TITLE
Fix serendipitously correct logic

### DIFF
--- a/javascript/froogaloop.js
+++ b/javascript/froogaloop.js
@@ -162,7 +162,7 @@ var Froogaloop = (function(){
 
         var value = data.value,
             eventData = data.data,
-            target_id = target_id === '' ? null : data.player_id,
+            target_id = data.player_id,
 
             callback = getCallback(method, target_id),
             params = [];


### PR DESCRIPTION
Summary: the logic to retrieve the target_id from a message received from the iframe couldn't possibly be correct, but behaved correctly anyways.  

The code before my change `target_id = target_id === '' ? null : data.player_id` compares an uninitialized variable `target_id` to a blank string, which can never be true.  However, the logic flow still works because a) the ternary operator always evaluates the falsey branch, and b) the falsey branch evaluates to a falsey value when `data.player_id` doesn't exist, and c) `getCallback` does the right thing when it receives a falsey value.

I replaced the code with the simplest possible thing that behaves the same, but there are certainly other ways to write it.  For example, the following line would evaluate to an explicit `null` when the player_id property does not exist at all:

`target_id = 'player_id' in data ? data.player_id : null`

I imagine this is closer to the original code's intent?

I do not see any tests, so I did not test this code.