### PR TITLE
Prevent error when event.data isn't formatted as a string

### DIFF
--- a/javascript/froogaloop.js
+++ b/javascript/froogaloop.js
@@ -134,7 +134,7 @@ var Froogaloop = (function(){
         var data, method;
 
         try {
-            data = JSON.parse(event.data);
+            data = ( typeof event.data === 'string' ? JSON.parse(event.data) : event.data );
             method = data.event || data.method;
         }
         catch(e)  {


### PR DESCRIPTION
This update will fix the following JS error in Chrome 44.0.2403.155:

![froogaloop-error](https://cloud.githubusercontent.com/assets/864716/9424735/983d90cc-48c5-11e5-9fcf-a12903b7b148.png)

Shows up on the official demo http://s.codepen.io/bdougherty/debug/FEuDd

Here's a fork with my fix applied http://s.codepen.io/tedw/debug/WvqBVa

Thanks!
